### PR TITLE
Automate syncing code to launchpad

### DIFF
--- a/.github/workflows/sync-repo.yaml
+++ b/.github/workflows/sync-repo.yaml
@@ -1,7 +1,15 @@
 ---
 
 name: Sync repo to Launchpad
-on: [ push ]
+on:
+  workflow_call:
+    secrets:
+      GIT_SSH_PRIVATE_KEY:
+        required: true
+      GIT_SSH_KNOWN_HOSTS:
+        required: true
+  push:
+
 
 jobs:
   to_launchpad:

--- a/.github/workflows/sync-repo.yaml
+++ b/.github/workflows/sync-repo.yaml
@@ -1,0 +1,15 @@
+---
+
+name: Sync repo to Launchpad
+on: [ push ]
+
+jobs:
+  to_launchpad:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: yesolutions/mirror-action@master
+        with:
+          REMOTE: 'ssh://neovim-snap@git.launchpad.net/neovim-snap'
+          GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_PRIVATE_KEY }}
+          GIT_SSH_KNOWN_HOSTS: ${{ secrets.GIT_SSH_KNOWN_HOSTS }}

--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -27,7 +27,7 @@ jobs:
           default_author: github_actions
 
   call-sync-repo:
-    uses: neovim/nvim-snap/.github/workflows/sync-repo.yaml
+    uses: ./.github/workflows/sync-repo.yaml
     secrets:
       GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_PRIVATE_KEY }}
       GIT_SSH_KNOWN_HOSTS: ${{ secrets.GIT_SSH_KNOWN_HOSTS }}

--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -8,13 +8,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set update date variable
+        run: |
+          UPDATE_DATE=$(date)
+          echo "UPDATE_DATE=${UPDATE_DATE}" >> $GITHUB_ENV
+
       - name: Update last sync date to launchpad
         env:
           BEGIN_TAG: "<!-- BEGIN SYNC INFO -->"
           END_TAG: "<!-- END SYNC INFO -->"
         run: |
-          TODAY=$(date)
-          UPDATE=$(cat README.md | perl -0777 -pe 's#(${{ env.BEGIN_TAG }})(?:.|\n)*?(${{ env.END_TAG }})#${1}\nLast sync to launchpad:${{ env.TODAY }}\n${2}#g')
+          UPDATE=$(cat README.md | perl -0777 -pe 's#(${{ env.BEGIN_TAG }})(?:.|\n)*?(${{ env.END_TAG }})#${1}\nLast sync to launchpad: ${{ env.UPDATE_DATE }}\n${2}#g')
           echo "${UPDATE}" > README.md
 
       - uses: EndBug/add-and-commit@v9

--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -25,3 +25,9 @@ jobs:
         with:
           message: "docs(readme): Bump sync date"
           default_author: github_actions
+
+  call-sync-repo:
+    uses: neovim/nvim-snap/.github/workflows/sync-repo.yaml
+    secrets:
+      GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_PRIVATE_KEY }}
+      GIT_SSH_KNOWN_HOSTS: ${{ secrets.GIT_SSH_KNOWN_HOSTS }}

--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -1,0 +1,23 @@
+---
+name: Update Readme
+on: workflow_dispatch
+
+jobs:
+  update_readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update last sync date to launchpad
+        env:
+          BEGIN_TAG: "<!-- BEGIN SYNC INFO -->"
+          END_TAG: "<!-- END SYNC INFO -->"
+        run: |
+          TODAY=$(date)
+          UPDATE=$(cat README.md | perl -0777 -pe 's#(${{ env.BEGIN_TAG }})(?:.|\n)*?(${{ env.END_TAG }})#${1}\nLast sync to launchpad:${{ env.TODAY }}\n${2}#g')
+          echo "${UPDATE}" > README.md
+
+      - uses: EndBug/add-and-commit@v9
+        with:
+          message: "docs(readme): Bump sync date"
+          default_author: github_actions

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ sudo snap install nvim --classic
 ## Last Launchpad Sync
 
 <!-- BEGIN SYNC INFO -->
-Last sync to launchpad: Dec 31, 2022
+Last sync to launchpad: Wed Jan  4 04:47:37 UTC 2023
 <!-- END SYNC INFO -->

--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ sudo snap install nvim --classic
 ```
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/nvim)
+
+## Last Launchpad Sync
+
+<!-- BEGIN SYNC INFO -->
+Last sync to launchpad: Dec 31, 2022
+<!-- END SYNC INFO -->


### PR DESCRIPTION
Launchpad is set to build snaps on new commits of this repo. The only requirement is to push the code to launchpad