### PR TITLE
Update stable snap to use stable branch, works for v0.10

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,7 +36,7 @@ parts:
     source: https://github.com/neovim/neovim.git
     override-pull: |
       craftctl default
-      branch="$(git tag -l --sort=refname | awk '/v[0-9\.]/{print $0}' | tail -1)"
+      branch="stable"
       git checkout tags/${branch} -b ${branch}
       major="$(awk '/NVIM_VERSION_MAJOR/{gsub(")","",$2); print $2}' CMakeLists.txt)"
       minor="$(awk '/NVIM_VERSION_MINOR/{gsub(")","",$2); print $2}' CMakeLists.txt)"


### PR DESCRIPTION
The current implementation of the snapcraft.yaml file selects the stable tag based on a regex to identify versioned releases and sorting them to find the latest stable release. However, it uses a string/alphanumeric sort, which stopped working with version 0.10 of Neovim. At that point, this sorting approach deemed 0.10.0 to be less than 0.9.5.

This changes the tag to simply be "stable", which points to the stable tag.

Test Plan:

```
Generated snap metadata
Lint OK:
- classic: Snap confinement is set to classic.
Lint warnings:
- classic: usr/bin/nvim: ELF interpreter should be set to '/snap/core22/current/lib64/ld-linux-x86-64.so.2'. (https://snapcraft.io/docs/linters-classic)
Created snap package nvim_v0.10.0_amd64.snap
```