### PR TITLE
use luajit2 for s390x

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,12 +43,16 @@ parts:
       patch="$(awk '/NVIM_VERSION_PATCH/{gsub(")","",$2); print $2}' CMakeLists.txt)"
       version="v$major.$minor.$patch"
       craftctl set version="${version}"
+      if [ "$SNAP_ARCH" = "s390x" ]; then
+        sed -i 's|^\(LUAJIT_URL\) .*|\1 https://github.com/openresty/luajit2/archive/refs/tags/v2.1-20250117.tar.gz|' cmake.deps/deps.txt
+        sed -i 's|^\(LUAJIT_SHA256\) .*|\1 68ff3dc2cc97969f7385679da7c9ff96738aa9cc275fa6bab77316eb3340ea8e|' cmake.deps/deps.txt
+      fi
     plugin: make
     override-build: |
       echo "Building on $SNAP_ARCH"
       set -x
       case "$SNAP_ARCH" in
-         "ppc64el"  | "s390x")
+         "ppc64el")
         make -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}" \
           CMAKE_BUILD_TYPE=RelWithDebInfo \
           CMAKE_INSTALL_PREFIX=/usr \


### PR DESCRIPTION
As described in #43, LuaJIT-support for s390x doesn't get merged.
Build neovim with `luajit2` on s390x to be able to use popular plugins like `lazy.nvim`, `telescope`, ...