### PR TITLE
Fix tree-sitter parsers installation.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,15 +96,22 @@ parts:
     plugin: nil
     after:
       - nvim
+    build-packages:
+      - libclang1-15
+      - libclang-common-15-dev
+      - cargo-1.89
+    build-environment:
+      - PATH: $PATH:$HOME/.cargo/bin
     override-build: |
+      cargo-1.89 install tree-sitter-cli
       mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
       git clone https://github.com/nvim-treesitter/nvim-treesitter ~/.local/share/nvim/site/pack/nvim-treesitter/start/nvim-treesitter
       mkdir -p ~/.local/share/nvim/site/pack/plenary.nvim/start
       git clone https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/plenary.nvim/start/plenary.nvim
-      $CRAFT_STAGE/usr/bin/nvim --headless -c "TSInstallSync all" -c "q"
+      $CRAFT_STAGE/usr/bin/nvim --headless -c "lua require('nvim-treesitter').install('all', {max_jobs = $SNAPCRAFT_PARALLEL_BUILD_COUNT}):wait(900000)" -c "q"
       parser_dest="$CRAFT_PART_INSTALL/usr/share/nvim/runtime/parser/"
       mkdir -p "$parser_dest"
-      cp ~/.local/share/nvim/site/pack/nvim-treesitter/start/nvim-treesitter/parser/* "$parser_dest"
+      cp ~/.local/share/nvim/site/parser/* "$parser_dest"
   patchelf:
     after:
       - treesitter-parsers


### PR DESCRIPTION
Attempt to fix https://github.com/neovim/neovim-snap/issues/51

- Replace TSInstallSync call, that's been deprecated.
- Install tree-sitter-cli, required to correctly compile parsers.